### PR TITLE
PDP10, PDP11, Unibus VAXen: Add auto configure support for CH11

### DIFF
--- a/PDP10/pdp10_ksio.c
+++ b/PDP10/pdp10_ksio.c
@@ -2009,6 +2009,8 @@ AUTO_CON auto_tab[] = {/*c  #v  am vm  fxa   fxv */
         {0000540}, {0540} },                             /* KMC11-A comm IOP-DUP ucode - fx CSR, fx VEC */
     { { "DMR" },         1,  2,  0, 0, 
         {0004000}, {0610} },                             /* DMR11 comm - fx CSR, fx VEC */
+    { { "CH" },          1,  1,  0, 0, 
+        {04140}, {0270} },                               /* CH11 - CHAOS Net - fx CSR, fx VEC */
 #else
     { { "QBA" },         1,  0,  0, 0, 
         {017500} },                                     /* doorbell - fx CSR, no VEC */

--- a/PDP11/pdp11_ch.c
+++ b/PDP11/pdp11_ch.c
@@ -304,7 +304,7 @@ t_stat ch_reset (DEVICE *dptr)
   tx_buffer[2] = 0;
   tx_buffer[3] = 0;
 
-  return SCPE_OK;
+  return auto_config (dptr->name, (dptr->flags & DEV_DIS)? 0 : 1);  /* auto config */
 }
 
 t_stat ch_ex (t_value *vptr, t_addr addr, UNIT *uptr, int32 sw)

--- a/PDP11/pdp11_io_lib.c
+++ b/PDP11/pdp11_io_lib.c
@@ -777,6 +777,8 @@ AUTO_CON auto_tab[] = {/*c  #v  am vm  fxa   fxv */
     { { NULL },          1,  2,  4, 8 },                /* DTC05, DECvoice */
     { { NULL },          1,  2,  8, 8 },                /* KWV32 (DSV11) */
     { { NULL },          1,  1, 64, 4 },                /* QZA */
+    { { "CH" },          1,  1,  0, 0, 
+        {04140}, {0270} },                              /* CH11 - CHAOS Net - fx CSR, fx VEC */
     { { NULL },         -1 }                            /* end table */
 };
 


### PR DESCRIPTION
This will set address and vector for the CH11.